### PR TITLE
evaluate entire flake thunk

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -222,7 +222,7 @@ static Flake getFlake(
         throw Error("source tree referenced by '%s' does not contain a '%s/flake.nix' file", lockedRef, lockedRef.subdir);
 
     Value vInfo;
-    state.evalFile(CanonPath(flakeFile), vInfo, true); // FIXME: symlink attack
+    state.evalFile(CanonPath(flakeFile), vInfo, false); // FIXME: symlink attack
 
     expectType(state, nAttrs, vInfo, state.positions.add({CanonPath(flakeFile)}, 1, 1));
 


### PR DESCRIPTION
This PR makes nix not consider flake.nix as trivial and thus allows it to be a thunk.

Thanks to 8f9a499e4d371c4b87e1373f0ce40ec3e62602a0, the following is possible on Nix Super(but not on vanilla Nix):
```nix
# flake.nix
{
   description = let in "NixOS configuration";
   
   inputs = let in {};
   
   outputs = let in inputs: {};
}
```
But the following fails on both Nix Super and vanilla Nix:
```nix
# flake.nix
let in {
   description = "NixOS configuration";
   
   inputs = {};
   
   outputs = inputs: {};
}
```

This PR allow the above code to be evaluated.


# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
If you can add `let in` to `description`, `inputs`, and `outputs`, it doesn't make sense why not to also allow evaluating of the entire flake.nix.

My project, [combined-manager](https://github.com/FlafyDev/combined-manager), requires this feature. 

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
