### PR TITLE
feat: add reject-flake-config setting to reject all nix config from flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The following experimental features are enabled by default:
 - `repl-flake` (`Xp::ReplFlake`)
 - `fetch-tree` (`Xp::FetchTree`)
 
+### Additional settings
+
+The following settings are added to this fork:
+- `reject-flake-config`: rejects all flake configuration (including whitelisted settings) and warns about it
+
 ### Full thunk evaluation in `flake.nix`
 
 In stock Nix, only the outputs section of `flake.nix` is able to make full use of the Nix language.

--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -51,6 +51,11 @@ void ConfigFile::apply()
         else
             assert(false);
 
+        if (nix::fetchSettings.rejectFlakeConfig) {
+            warn("ignoring untrusted flake configuration setting '%s' due to the '%s' setting.", name, "reject-flake-config");
+            continue;
+        }
+
         if (!whitelist.count(baseName) && !nix::fetchSettings.acceptFlakeConfig) {
             bool trusted = false;
             auto trustedList = readTrustedList();

--- a/src/libfetchers/fetch-settings.hh
+++ b/src/libfetchers/fetch-settings.hh
@@ -87,6 +87,10 @@ struct FetchSettings : public Config
         "Whether to accept nix configuration from a flake without prompting.",
         {}, true, Xp::Flakes};
 
+    Setting<bool> rejectFlakeConfig{this, false, "reject-flake-config",
+        "Whether to reject nix configuration (including whitelisted settings) from a flake without prompting.",
+        {}, true, Xp::Flakes};
+
     Setting<std::string> commitLockFileSummary{
         this, "", "commit-lockfile-summary",
         R"(


### PR DESCRIPTION

# Motivation

* Flakes can silently set certain whitelisted settings
* Rejecting flake config is cumbersome - rejecting must be done one-by-one

# Context

This setting allows rejecting all flake config (via CLI or nix.conf) and warns about rejected config

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
