### PR TITLE
Evaluate entire flake thunk

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -214,7 +214,7 @@ static Flake readFlake(
 
     // NOTE evalFile forces vInfo to be an attrset because mustBeTrivial is true.
     Value vInfo;
-    state.evalFile(flakePath, vInfo, true);
+    state.evalFile(flakePath, vInfo, false);
 
     Flake flake {
         .originalRef = originalRef,


### PR DESCRIPTION
# Motivation
If you can add let in to description, inputs, and outputs, it doesn't make sense why not to also allow evaluating of the entire flake.nix.

FlafyDev's project, [combined-manager](https://github.com/FlafyDev/combined-manager), requires this feature.

# Context

This feature has already been added by https://github.com/privatevoid-net/nix-super/pull/12 but is currently not working.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).